### PR TITLE
Add a workspace toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 debug/
 target/
 
+.idea
+
 Cargo.lock
 
 **/*.rs.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,25 @@
+
+[workspace]
+members = [
+    "crates/s3s",
+    "crates/s3s-aws",
+    "crates/sprox",
+]
+#exclude = ["datafusion-cli", "dev/depcheck"]
+resolver = "2"
+
+[workspace.package]
+authors = ["Sprox Authors <todo@example.com>"]
+version = "0.10.0-dev"
+edition = "2021"
+description = "An experimental S3-compatible proxy for accelerating embedded analytics"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/datafusion-contrib/datafusion-sprox"
+keywords = ["s3", "datafusion"]
+categories = ["web-programming"]
+rust-version = "1.73"
+
+[workspace.dependencies]
+s3s-aws = { version = "0.10.0-dev", path = "crates/s3s-aws" }
+s3s = { version = "0.10.0-dev", path = "crates/s3s" }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Projects like [DataFusion](https://arrow.apache.org/datafusion/), [Velox](https:
 
 But as awesome as S3 is, continuously `GET`ing files from it for local/embedded analytical workflows is silly ([and maybe even problematic](https://www.mdpi.com/2076-3417/11/18/8540)).
 
+Read more in [README.md](crates/sprox/README.md) and [dev/DREAMS.md](dev/DREAMS.md).
+
 # Inspiration(s)
 
 * [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/)

--- a/crates/sprox/Cargo.toml
+++ b/crates/sprox/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sprox"
-version = "0.1.0-dev"
-edition = "2021"
-description = "An experimental S3-compatible proxy for accelerating embedded analytics"
-license = "Apache-2.0"
+version = {workspace = true}
+edition = {workspace = true}
+description =  {workspace = true}
+license = {workspace = true}
 
 [[bin]]
 name = "sprox"
@@ -11,6 +11,7 @@ required-features = ["binary"]
 
 [features]
 binary = ["tokio/full", "dep:clap", "dep:tracing-subscriber", "dep:hyper-util"]
+default = ["binary"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -38,7 +39,7 @@ mime = "0.3.17"
 nugine-rust-utils = "0.3.1"
 numeric_cast = "0.2.1"
 path-absolutize = "3.1.0"
-s3s = { version = "0.10.0-dev", path = "../s3s" }
+s3s = { workspace = true }
 serde_json = "1.0.104"
 sha1 = "0.10.5"
 sha2 = "0.10.7"
@@ -61,6 +62,6 @@ aws-config = { version = "1.1.2", default-features = false }
 aws-credential-types = { version = "1.1.2", features = ["test-util"] }
 aws-sdk-s3 = { version = "1.12.0", features = ["behavior-version-latest"] }
 once_cell = "1.18.0"
-s3s-aws = { version = "0.10.0-dev", path = "../s3s-aws" }
+s3s-aws = { workspace = true }
 tokio = { version = "1.31.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time"] }

--- a/crates/sprox/README.md
+++ b/crates/sprox/README.md
@@ -1,7 +1,7 @@
 # Get Sprox Running
 The following command runs `sprox` locally, using the `data` directory as S3 root.
 
-    $ RUST_LOG=debug cargo run --features=binary data --access-key=A --secret-key=B
+    $ RUST_LOG=debug cargo run  data --access-key=A --secret-key=B
 
 
 # Throw AWS config into env so it doesn't need to be sourced continuously:


### PR DESCRIPTION
## How cool is this PR?

<!--
On a cool factor of 1-10, how cool is this PR? And why?
-->
🧊 : 2

1. makes a workspace cargo.toml file (so you can open an IDE in the main workspace root),
2. avoids the need to say `--features=binary`
3. adds a link in the main readme to sprox specific readme